### PR TITLE
fix pubsub message trigger

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ exports.initWatch = (req, res) => {
 */
 exports.onNewMessage = (event) => {
   // Parse the Pub/Sub message
-  const dataStr = Buffer.from(event.data.data, 'base64').toString('ascii');
+  const dataStr = Buffer.from(event.data, 'base64').toString('ascii');
   const dataObj = JSON.parse(dataStr);
 
   return oauth.fetchToken(dataObj.emailAddress)


### PR DESCRIPTION
Fix the error 'TypeError: First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object' caused due to incorrect calling of the event.data argument in Buffer.from call